### PR TITLE
Bugfix/fixing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To run these tests, do this:
 npm run test:non-browser
 ```
 
-### wdio Tests
+### wdio Tests (including e2e)
 
 Many of the Cucumber Common functions are written to run in the context of wdio, in synchronous mode. In order to run an environment as close to this as possible some of the tests are written using Mocha, and executed with wdio as the test runner.
 
@@ -40,7 +40,8 @@ or like this:
 npm run test:wdio
 ```
 
+If you are running the e2e tests individually, ensure you have started the test server first by running `npm run test:start-server`
 
 ## Persona Engine
 
-[Go here](./persona-engine/README.md) for the persona engine docs
+[Go here](./test-asset-generator/engines/persona-engine/README.md) for the persona engine docs

--- a/lib/cucumber/steps/personas.js
+++ b/lib/cucumber/steps/personas.js
@@ -1,5 +1,5 @@
 const Step = require('cucumber').defineStep
-const personaGetter = require('../../../test-asset-generator/persona-engine')
+const personaGetter = require('../../../test-asset-generator/engines/persona-engine')
 
 
 Step(/^I am logged in as (.*)$/, actor => {

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "start-transformer": "node -r esm index-transformer.js",
     "start": "node index.js",
-    "start-test-server": "http-server ./lib/fixtures",
+    "start-test-server": "http-server -p 8080 ./lib/fixtures",
     "test": "run-p test:**",
     "test:non-browser": "tap --esm --no-cov test/unit/**/*.js",
     "test:wdio": "wdio --spec test/wdio/*.js test/mocha.wdio.conf.js",
-    "test:e2e": "wdio test/wdio.conf.js"
+    "test:e2e": "npm run start-test-server & wdio test/wdio.conf.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "start-transformer": "node -r esm index-transformer.js",
     "start": "node index.js",
-    "start-test-server": "http-server -p 8080 ./lib/fixtures",
     "test": "run-p test:**",
+    "test:start-server": "http-server -p 8080 ./lib/fixtures",
     "test:non-browser": "tap --esm --no-cov test/unit/**/*.js",
     "test:wdio": "wdio --spec test/wdio/*.js test/mocha.wdio.conf.js",
-    "test:e2e": "npm run start-test-server & wdio test/wdio.conf.js"
+    "test:e2e": "wdio test/wdio.conf.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Overview: 
e2e tests were not working due to incorrect migration to single use repo. Fixed paths and updated a script to make them pass.

## Work carried out:

- [x] Renamed `start-test-server` to `test:start-server` so that `npm test` runs it
- [x] Corrected path in `personas.js`
- [x] Updated readme

## Screenshot

![2019-07-30 09 30 37](https://user-images.githubusercontent.com/151028/62113659-e2297e80-b2ac-11e9-97f7-6440a19065aa.gif)

