### PR TITLE
Feature/sis 3659 xpathwithtextrefactor

### DIFF
--- a/lib/string/xpath-builder.js
+++ b/lib/string/xpath-builder.js
@@ -34,6 +34,9 @@ const xPathBuilder = (elementType) => {
   }
 }
 
+const xWithText =(thing, text) =>
+  thing.replace(']', ` and normalize-space()="${text}"]`)
+
 /**
  * Builds an XPath using xPathBuilder with a string at the end
  *
@@ -41,9 +44,8 @@ const xPathBuilder = (elementType) => {
  * @param {string} text the content of the element
  */
 
- const xPathWithText = (elementType, text) => 
-  xPathBuilder(elementType)
-    .replace(']', ` and normalize-space()="${text}"]`)
+ const xPathWithText = (elementType, text) => xWithText(xPathBuilder(elementType), text)
+    
 
 const xPathWithDataHook = (elementType, dataHook) => {
   const xpath = xPathBuilder(elementType)
@@ -58,11 +60,8 @@ const xPathWithDataHook = (elementType, dataHook) => {
   return mutatedXpath
 }
 
-// TODO: https://vmddefra.atlassian.net/browse/SIS-3659
 const xPathWithDataHookAndText = (elementType, dataHook, text) => 
-  xPathBuilder(elementType)
-    .replace(/ or/gm, `[contains(@data-hook, "${dataHook}")] or`)
-    .replace(']', `and normalize-space()="${text}"]`)
+  xWithText(xPathWithDataHook(elementType, dataHook), text)
 
 module.exports = {
   elementExtractor,


### PR DESCRIPTION

## Ticket
https://vmddefra.atlassian.net/browse/SIS-3659

## Overview: 
Refactored the xpath selectors in CC library to be more DRY

## Reason: 
DRY (Don't Repeat Yourself) code is easier to maintain and less fragile.

## Work carried out:

- [x] Created `xWithText` function
- [x] refactored `xPathWithText` and `xPathWithDataHookAndText` to use `xWithText`